### PR TITLE
feat: Add Shadcn UI component sources and update dependencies

### DIFF
--- a/zt-immune-system/dashboard/frontend/package.json
+++ b/zt-immune-system/dashboard/frontend/package.json
@@ -11,7 +11,10 @@
     "format": "prettier --write ."
   },
   "dependencies": {
+    "@radix-ui/react-label": "^2.0.2",
+    "@radix-ui/react-scroll-area": "^1.0.5",
     "@radix-ui/react-slot": "^1.0.2",
+    "@radix-ui/react-tabs": "^1.0.4",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "lucide-react": "^0.372.0",

--- a/zt-immune-system/dashboard/frontend/src/components/ui/scroll-area.jsx
+++ b/zt-immune-system/dashboard/frontend/src/components/ui/scroll-area.jsx
@@ -1,0 +1,38 @@
+import * as React from "react"
+import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
+
+import { cn } from "@/lib/utils" // Assumes @ is aliased to src/
+
+const ScrollArea = React.forwardRef(({ className, children, ...props }, ref) => (
+  <ScrollAreaPrimitive.Root
+    ref={ref}
+    className={cn("relative overflow-hidden", className)}
+    {...props}>
+    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+      {children}
+    </ScrollAreaPrimitive.Viewport>
+    <ScrollBar />
+    <ScrollAreaPrimitive.Corner />
+  </ScrollAreaPrimitive.Root>
+))
+ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName
+
+const ScrollBar = React.forwardRef(({ className, orientation = "vertical", ...props }, ref) => (
+  <ScrollAreaPrimitive.Scrollbar
+    ref={ref}
+    orientation={orientation}
+    className={cn(
+      "flex touch-none select-none transition-colors",
+      orientation === "vertical" &&
+        "h-full w-2.5 border-l border-l-transparent p-[1px]",
+      orientation === "horizontal" &&
+        "h-2.5 flex-col border-t border-t-transparent p-[1px]",
+      className
+    )}
+    {...props}>
+    <ScrollAreaPrimitive.Thumb className="relative flex-1 rounded-full bg-border" />
+  </ScrollAreaPrimitive.Scrollbar>
+))
+ScrollBar.displayName = ScrollAreaPrimitive.Scrollbar.displayName
+
+export { ScrollArea, ScrollBar }


### PR DESCRIPTION
I've added the source code for a comprehensive set of Shadcn UI components to your `zt-immune-system/dashboard/frontend/src/components/ui/` directory. This makes the previously styled frontend components functional by providing their underlying implementations. I also updated `package.json` with new Radix UI dependencies required by these components.

Key changes:

- I created `src/lib/utils.js` with the `cn` helper function, essential for Shadcn UI components.
- I ensured the `src/components/ui/` directory exists.
- I added standard Shadcn UI source code for the following components:
    - `button.jsx` (Button)
    - `card.jsx` (Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter)
    - `tabs.jsx` (Tabs, TabsList, TabsTrigger, TabsContent)
    - `input.jsx` (Input)
    - `label.jsx` (Label)
    - `table.jsx` (Table and its sub-components)
    - `badge.jsx` (Badge)
    - `scroll-area.jsx` (ScrollArea, ScrollBar)
- I updated `package.json` to include the following new dependencies required by the Shadcn UI components:
    - `@radix-ui/react-label`
    - `@radix-ui/react-scroll-area`
    - `@radix-ui/react-tabs`

This completes the setup of the core Shadcn UI building blocks for the ZT Immune System dashboard frontend.