### PR TITLE
feat: Implement Dockerized honeypot environment

### DIFF
--- a/zt-immune-system/honeypots/README.md
+++ b/zt-immune-system/honeypots/README.md
@@ -1,0 +1,168 @@
+# ZT Immune System - Honeypots Module
+
+## Overview
+
+This directory contains a collection of diverse honeypots, containerized using Docker and orchestrated with Docker Compose. The primary goal is to provide a modular and extensible setup for deploying various types of honeypots to capture and analyze different attack vectors.
+
+The setup is designed to be easily deployable and manageable, leveraging Docker for isolation and Docker Compose for service definition and orchestration.
+
+## Prerequisites
+
+Before you begin, ensure you have the following installed:
+-   **Docker:** [Installation Guide](https://docs.docker.com/engine/install/)
+-   **Docker Compose:** [Installation Guide](https://docs.docker.com/compose/install/)
+
+## Included Honeypots
+
+This setup currently includes the following honeypots, each in its own subdirectory:
+
+-   **Cowrie (`./cowrie`)**:
+    -   A medium to high interaction SSH and Telnet honeypot designed to log brute force attacks and shell interaction performed by the attacker.
+    -   Homepage: [Cowrie GitHub](https://github.com/cowrie/cowrie)
+-   **mhnet (`./mhnet`)**:
+    -   A placeholder for a custom honeypot or a sensor for the Modern Honey Network (MHN).
+    -   The `mhnet_setup.sh` script is intended to be customized by the user to deploy their desired honeypot service.
+-   **T-Pot (`./tpot`)**:
+    -   Provides a basic environment to run T-Pot components. T-Pot itself is a multi-honeypot platform.
+    -   This is a placeholder and requires significant user configuration within `tpot/start.sh` and `tpot/config.yaml` to deploy a functional T-Pot instance or selected components.
+    -   Homepage: [T-Pot GitHub](https://github.com/telekom-security/tpotce)
+
+## Directory Structure
+
+```
+zt-immune-system/
+├── honeypots/
+│   ├── docker-compose.yml  # Main Docker Compose file for orchestrating honeypots
+│   ├── cowrie/             # Cowrie honeypot specific files (Dockerfile, config, etc.)
+│   │   ├── Dockerfile
+│   │   ├── cowrie.cfg      # Default Cowrie configuration (built into image)
+│   │   └── start_cowrie.sh # Script to start Cowrie
+│   ├── mhnet/              # Placeholder for custom/MHN honeypot
+│   │   ├── Dockerfile
+│   │   └── mhnet_setup.sh  # User-defined setup and execution script
+│   ├── tpot/               # Placeholder for T-Pot components
+│   │   ├── Dockerfile
+│   │   ├── config.yaml     # Placeholder T-Pot configuration
+│   │   └── start.sh        # Placeholder T-Pot startup script
+│   └── README.md           # This file
+└── infrastructure/
+    └── docker/
+        ├── seccomp_profile.json # Default seccomp profile for containers
+        ├── apparmor_profile.conf # Example AppArmor profile
+        └── selinux_policy.te    # Example SELinux policy type enforcement file
+```
+
+-   **`docker-compose.yml`**: Defines the services, networks, and volumes for the honeypot deployment.
+-   **`cowrie/`**: Contains the Dockerfile, default `cowrie.cfg`, and startup script for the Cowrie honeypot.
+-   **`mhnet/`**: Contains a generic Dockerfile and `mhnet_setup.sh` which must be populated by the user to deploy a specific honeypot.
+-   **`tpot/`**: Contains a generic Dockerfile, a placeholder `config.yaml`, and `start.sh` for users to integrate T-Pot or its components.
+
+## Getting Started
+
+1.  **Build the Docker images:**
+    Open a terminal in the `zt-immune-system/honeypots/` directory and run:
+    ```bash
+    docker-compose build
+    ```
+
+2.  **Start the honeypot services:**
+    To start the services in detached mode:
+    ```bash
+    docker-compose up -d
+    ```
+
+3.  **Check the status of running services:**
+    ```bash
+    docker-compose ps
+    ```
+
+4.  **View logs for a specific service:**
+    For example, to view Cowrie logs:
+    ```bash
+    docker-compose logs cowrie
+    docker-compose logs -f cowrie # To follow logs
+    ```
+
+5.  **Stop and remove the services:**
+    ```bash
+    docker-compose down
+    ```
+    To remove volumes as well (deletes persisted data):
+    ```bash
+    docker-compose down -v
+    ```
+
+## Configuration & Customization
+
+### General
+
+-   **Environment Variables**: Common service configurations (like hostnames or service identifiers) can be set via environment variables in the `docker-compose.yml` file for each service.
+
+### Cowrie (`./cowrie`)
+
+-   **Configuration File**: The primary configuration for Cowrie is `cowrie/cowrie.cfg`. A default version is built into the Docker image at `/home/cowrie/cowrie/etc/cowrie.cfg.dist`.
+-   **Overriding Configuration**: To customize the Cowrie configuration, you can:
+    1.  Modify `cowrie/cowrie.cfg` **before building the image**.
+    2.  Or, for runtime changes without rebuilding, uncomment the volume mount in `docker-compose.yml` to map your local `cowrie/cowrie.cfg` to `/home/cowrie/cowrie/etc/cowrie.cfg.dist` (or `/home/cowrie/cowrie/cowrie.cfg` depending on how Cowrie loads it, typically it's `.dist` then copied).
+        ```yaml
+        # In docker-compose.yml services.cowrie.volumes:
+        # - ./cowrie/cowrie.cfg:/home/cowrie/cowrie/etc/cowrie.cfg.dist:ro
+        ```
+-   **Hostname**: The `COWRIE_HOSTNAME` environment variable in `docker-compose.yml` can be used by Cowrie if its configuration is set up to read it (the provided `cowrie.cfg` sets a static hostname).
+
+### mhnet (`./mhnet`)
+
+-   **Setup Script**: The core logic for this honeypot resides in `mhnet/mhnet_setup.sh`. You need to populate this script with commands to install dependencies, configure, and run your chosen honeypot service.
+-   **Environment Variable**: `MHNET_SERVICE_NAME` in `docker-compose.yml` is an example of how you might pass configuration to your setup script.
+
+### T-Pot (`./tpot`)
+
+-   **Startup Script & Config**: Customization happens in `tpot/start.sh` and `tpot/config.yaml`. These are placeholders and require user implementation to deploy T-Pot components.
+-   **Complexity**: A full T-Pot deployment is complex and may require:
+    -   Additional Docker capabilities (e.g., `cap_add: [NET_ADMIN, NET_RAW]`).
+    -   Specific network configurations (host mode, many port mappings).
+    -   Potentially Docker-in-Docker (mounting `/var/run/docker.sock`), which has significant security implications.
+    -   Adjustments to `sysctls`.
+    The current Dockerfile and service definition are minimal and provide a basic environment.
+-   **Environment Variable**: `TPOT_FLAVOR` in `docker-compose.yml` is an example for use in `start.sh`.
+
+## Logging
+
+-   **Cowrie**: Configured to output JSON logs to `stdout` by default (see `cowrie/cowrie.cfg`). These can be accessed via `docker-compose logs cowrie`.
+-   **mhnet / T-Pot**: Logging behavior is dependent on the user's implementation within the respective `mhnet_setup.sh` and `tpot/start.sh` scripts. It's recommended to configure these services to log to `stdout`/`stderr` for easy collection with `docker-compose logs`.
+
+## Security Considerations
+
+Security is paramount when deploying honeypots, as they are intentionally exposed to attract malicious activity.
+
+-   **Container Security**:
+    -   `no-new-privileges:true`: Prevents containers from gaining new privileges.
+    -   `seccomp` profile: A default seccomp profile (`../infrastructure/docker/seccomp_profile.json`) is applied to restrict allowed syscalls, reducing the kernel attack surface.
+-   **Further Enhancements (System-Level)**:
+    -   **AppArmor**: Consider applying AppArmor profiles (example: `../infrastructure/docker/apparmor_profile.conf`) for mandatory access control.
+    -   **SELinux**: If your host uses SELinux, custom SELinux policies (example: `../infrastructure/docker/selinux_policy.te`) can provide more granular control.
+-   **Network Isolation**:
+    -   It is crucial to isolate the honeypot network from your production networks. The `honeynet` Docker bridge network provides basic isolation at the Docker level.
+    -   Ensure your host firewall rules are configured to only expose intended honeypot ports to the desired zones (e.g., internet-facing, internal segments).
+    -   **Never expose management interfaces of Docker or the host system to untrusted networks.**
+-   **Resource Limits**: Configure resource limits (CPU, memory) in `docker-compose.yml` for each service to prevent a compromised honeypot from consuming excessive host resources.
+
+## Data Persistence
+
+-   **Cowrie**: Persists data (like downloaded malware, TTY logs if not to stdout) to the `cowrie_data` Docker volume, mounted at `/home/cowrie/cowrie/var/lib/cowrie`.
+-   **mhnet**: A `mhnet_data` volume is defined and can be used by the custom script in `mhnet_setup.sh` by mounting it to an appropriate path (e.g., `/opt/mhnet/data`).
+-   **T-Pot**: Data persistence for T-Pot is complex and depends on the deployed components. The `tpot_data` volume is commented out in `docker-compose.yml` and should be specifically configured by the user as needed.
+
+## Flexibility and Extensibility
+
+-   **`mhnet` as a Template**: The `mhnet` service is a flexible template. You can adapt `mhnet/Dockerfile` and `mhnet/mhnet_setup.sh` to run virtually any honeypot that can be containerized.
+-   **`tpot` as an Environment**: The `tpot` service provides a starting point for integrating components of the T-Pot framework or other complex honeypot distributions.
+-   **Adding New Honeypots**: To add a new honeypot:
+    1.  Create a new subdirectory (e.g., `./myhoneypot/`).
+    2.  Add a `Dockerfile` and any necessary configuration/startup scripts within it.
+    3.  Define a new service in `docker-compose.yml` similar to the existing ones.
+
+---
+
+Remember to regularly update the base images and honeypot software to patch vulnerabilities and get the latest features.
+Happy honeypotting!

--- a/zt-immune-system/honeypots/cowrie/Dockerfile
+++ b/zt-immune-system/honeypots/cowrie/Dockerfile
@@ -1,0 +1,50 @@
+# 1. Start from a suitable base image
+FROM python:3.9-slim
+
+# 2. Install necessary dependencies
+RUN apt-get update && apt-get install -y \
+    git \
+    virtualenv \
+    libssl-dev \
+    libffi-dev \
+    build-essential \
+    python3-dev \
+    authbind \
+    --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/*
+
+# 3. Create a non-root user cowrie
+RUN groupadd -r cowrie && useradd -r -g cowrie -d /home/cowrie -s /sbin/nologin -c "Cowrie Honeypot" cowrie
+RUN mkdir -p /home/cowrie && chown -R cowrie:cowrie /home/cowrie
+
+# 4. Switch to the cowrie user
+USER cowrie
+
+# 5. Set up a working directory
+WORKDIR /home/cowrie
+
+# 6. Clone the official Cowrie git repository
+RUN git clone https://github.com/cowrie/cowrie.git cowrie
+WORKDIR /home/cowrie/cowrie
+
+# 7. Create and activate a Python virtual environment
+RUN python3 -m venv .env
+# Note: Activation is handled by sourcing in the entrypoint/cmd, not directly here
+
+# 8. Install Python dependencies
+RUN .env/bin/pip install --no-cache-dir -r requirements.txt
+
+# 9. Copy the cowrie.cfg into the container
+# This file is expected to be in the build context
+COPY cowrie.cfg /home/cowrie/cowrie/etc/cowrie.cfg.dist
+
+# 10. Expose ports 2222 (SSH) and 2223 (Telnet)
+EXPOSE 2222
+EXPOSE 2223
+
+# 11. Set an appropriate entrypoint or command to run Cowrie
+# Assume start_cowrie.sh will be in the Cowrie home directory (/home/cowrie/cowrie)
+# and will handle activating the venv and starting cowrie
+COPY start_cowrie.sh /home/cowrie/cowrie/start_cowrie.sh
+RUN chmod +x /home/cowrie/cowrie/start_cowrie.sh
+ENTRYPOINT ["/home/cowrie/cowrie/start_cowrie.sh"]

--- a/zt-immune-system/honeypots/cowrie/cowrie.cfg
+++ b/zt-immune-system/honeypots/cowrie/cowrie.cfg
@@ -1,0 +1,129 @@
+# Cowrie Honeypot Configuration File
+
+[cowrie]
+# Hostname for the honeypot. Used in log messages and some interactions.
+hostname = svr04
+
+# Default listen addresses and ports.
+# These are typically overridden by command line or Docker port mapping in production.
+# The Dockerfile exposes 2222 and 2223.
+# The actual binding in the container will use these specific ports.
+listen_endpoints = tcp:2222:interface=0.0.0.0, tcp:2223:interface=0.0.0.0
+
+# Path to the data directory. Cowrie stores its downloads, session logs (TTYs), etc. here.
+# This path is relative to the Cowrie root directory (/home/cowrie/cowrie).
+data_path = var/lib/cowrie
+
+# Path to the text log files directory.
+# This is also relative to the Cowrie root.
+# Disabled by default in this config in favor of JSON to stdout.
+log_path = var/log/cowrie
+
+# Download path for malware/files collected by the honeypot.
+download_path = ${data_path}/downloads
+
+# Filesystem content path.
+# This points to the fake filesystem provided to attackers.
+filesystem_file = share/cowrie/fs.pickle
+
+# SSH specific configuration
+[ssh]
+# Listen on port 2222 for SSH connections.
+# The Dockerfile should expose this port.
+listen_endpoints = tcp:2222:interface=0.0.0.0
+
+# Enable/disable SSH support.
+enabled = true
+
+# SSH version string presented to clients.
+version_string = SSH-2.0-OpenSSH_7.2p2 Ubuntu-4ubuntu2.10
+
+# Telnet specific configuration
+[telnet]
+# Listen on port 2223 for Telnet connections.
+# The Dockerfile should expose this port.
+listen_endpoints = tcp:2223:interface=0.0.0.0
+
+# Enable/disable Telnet support.
+enabled = true
+
+
+# Output plugin configurations
+# -----------------------------
+
+# JSON logging output plugin
+[output_jsonlog]
+# Enable logging Cowrie events in JSON format.
+enabled = true
+# Log to stdout for easy capture by Docker log collectors.
+logfile = stdout
+# If you wanted to log to a file instead:
+# logfile = ${log_path}/cowrie.json
+
+# Text logging output plugin
+[output_textlog]
+# Disable standard text logging to avoid redundancy if JSON is sent to stdout.
+# If jsonlog is to a file, you might want to enable this for human-readable logs.
+enabled = false
+# Default logfile if enabled:
+# logfile = ${log_path}/cowrie.log
+# format = default
+
+# Other output plugins can be configured here (e.g., hpfeeds, splunk, elasticsearch)
+# [output_hpfeeds]
+# enabled = false
+# server = hpfeeds.example.com
+# port = 10000
+# identifier = xxxxxxxx
+# secret = yyyyyyyy
+# channel_logfile = cowrie.sessions
+# channel_alerts = cowrie.alerts
+
+# [output_elasticsearch]
+# enabled = false
+# host = localhost
+# port = 9200
+# index_prefix = cowrie
+# username = elastic
+# password = changeme
+
+# Input plugin configurations (e.g., command processing, proxying)
+# -----------------------------------------------------------------
+[input_telnet]
+# Max login attempts for Telnet.
+max_login_attempts = 3
+
+[input_ssh]
+# Max login attempts for SSH.
+max_login_attempts = 3
+
+# SFTP support (part of SSH)
+[sftp]
+enabled = true
+# Max files that can be uploaded via SFTP per session.
+max_files = 10
+# Max size for a single uploaded file (in bytes).
+max_file_size = 10485760 # 10MB
+
+# Shell interaction
+[shell]
+# Default shell prompt.
+prompt = # # This is for root-like shells, adjust if mimicking a non-root user by default
+# prompt = $ # For non-root users
+
+# Default environment variables for the shell.
+# These can be customized to mimic specific systems.
+env_vars = PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin,LANG=en_US.UTF-8
+
+# Misc settings
+# -------------
+# Enable capturing of TTY logs (session recordings).
+[ttylog]
+enabled = true
+# Path for TTY logs, relative to data_path.
+log_path = tty
+
+# Proxy settings (if Cowrie needs to connect out via a proxy)
+# [proxy]
+# http_url = http://proxy.example.com:8080
+# https_url = https://proxy.example.com:8080

--- a/zt-immune-system/honeypots/cowrie/start_cowrie.sh
+++ b/zt-immune-system/honeypots/cowrie/start_cowrie.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# Activate virtual environment
+cd /home/cowrie/cowrie
+. .env/bin/activate
+
+# Start Cowrie
+# Using bin/cowrie instead of cowrie command directly as per cowrie docs for foreground
+# The -n option keeps cowrie in the foreground, which is necessary for Docker containers
+exec bin/cowrie start -n

--- a/zt-immune-system/honeypots/docker-compose.yml
+++ b/zt-immune-system/honeypots/docker-compose.yml
@@ -1,0 +1,83 @@
+version: '3.8'
+
+networks:
+  honeynet:
+    driver: bridge
+
+volumes:
+  cowrie_data:
+  mhnet_data:
+  # tpot_data: # T-Pot's data management is complex; manage within its own scripts or define more specifically later.
+
+services:
+  cowrie:
+    build:
+      context: ./cowrie
+    image: zt_cowrie_honeypot # Add a custom image name
+    container_name: zt_cowrie
+    restart: unless-stopped
+    ports:
+      - "2222:2222" # SSH
+      - "2223:2223" # Telnet
+    volumes:
+      - cowrie_data:/home/cowrie/cowrie/var/lib/cowrie # For persistent data like downloads, logs if not to stdout
+      # cowrie.cfg is part of the image. To override, uncomment below:
+      # - ./cowrie/cowrie.cfg:/home/cowrie/cowrie/etc/cowrie.cfg.dist:ro
+    networks:
+      - honeynet
+    security_opt:
+      - "no-new-privileges:true"
+      - "seccomp:./../infrastructure/docker/seccomp_profile.json" # Path relative to docker-compose.yml
+    environment:
+      - COWRIE_HOSTNAME=honeypot-ssh-01 # Example, can be overridden
+
+  mhnet:
+    build:
+      context: ./mhnet
+    image: zt_mhnet_honeypot # Add a custom image name
+    container_name: zt_mhnet
+    restart: unless-stopped
+    # Ports should be defined by the user as mhnet_setup.sh is a placeholder
+    # ports:
+    #   - "xxxx:xxxx"
+    volumes:
+      - mhnet_data:/opt/mhnet/data # Generic data volume
+      # mhnet_setup.sh is part of the image.
+    networks:
+      - honeynet
+    security_opt:
+      - "no-new-privileges:true"
+      - "seccomp:./../infrastructure/docker/seccomp_profile.json" # Path relative to docker-compose.yml
+    environment:
+      - MHNET_SERVICE_NAME=generic-honeypot-01 # Example
+
+  tpot:
+    build:
+      context: ./tpot
+    image: zt_tpot_honeypot # Add a custom image name
+    container_name: zt_tpot
+    restart: unless-stopped
+    # T-Pot requires extensive port mapping. This should be handled by its internal setup
+    # or explicitly defined here once T-Pot is configured within start.sh.
+    # For full T-Pot, many capabilities and host configurations might be needed.
+    # This service is a placeholder for an environment to run T-Pot components.
+    # volumes:
+    #   - tpot_data:/opt/tpot/data # Placeholder, T-Pot's data needs are complex
+    #   - ./tpot/config.yaml:/opt/tpot/config.yaml:ro # Copied by Dockerfile, mount if externalizing
+    #   - /var/run/docker.sock:/var/run/docker.sock # Only if T-Pot needs to manage sibling containers (DANGEROUS)
+    networks:
+      - honeynet
+    security_opt:
+      - "no-new-privileges:true"
+      # Seccomp profile might be too restrictive for full T-Pot, which may need more syscalls.
+      # For the current placeholder start.sh, it's fine.
+      # If T-Pot's start.sh tries to install/run many things, this might need adjustment or removal for the tpot service.
+      - "seccomp:./../infrastructure/docker/seccomp_profile.json" # Path relative to docker-compose.yml
+    environment:
+      - TPOT_FLAVOR=standard # Example, for tpot start.sh to potentially use
+    # cap_add:
+    #   - NET_ADMIN # Example, T-Pot components often need extra capabilities
+    #   - NET_RAW
+    # sysctls: # Example, some components might need these
+    #   - net.core.somaxconn=1024
+    #   - net.ipv4.ip_forward=1

--- a/zt-immune-system/honeypots/mhnet/Dockerfile
+++ b/zt-immune-system/honeypots/mhnet/Dockerfile
@@ -1,0 +1,43 @@
+# Generic Dockerfile for mhnet honeypot
+# This Dockerfile provides a basic structure.
+# The actual honeypot setup and execution logic should be implemented
+# in the mhnet_setup.sh script.
+
+# 1. Start from a basic OS image
+FROM debian:bullseye-slim
+
+# Install any common dependencies that most honeypots might need.
+# sudo is included in case the setup script needs to elevate privileges temporarily,
+# though it's generally better to set up permissions correctly.
+RUN apt-get update && apt-get install -y \
+    sudo \
+    --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/*
+
+# 2. Create a non-root user
+RUN groupadd -r honeypot_user && \
+    useradd -r -g honeypot_user -d /home/honeypot_user -s /bin/bash -c "Honeypot User" honeypot_user && \
+    mkdir -p /home/honeypot_user && \
+    chown -R honeypot_user:honeypot_user /home/honeypot_user
+
+# Allow honeypot_user to run sudo commands without a password (use with caution)
+# This might be needed by some honeypot setup scripts.
+# Consider removing or restricting this if not strictly necessary for your honeypot.
+RUN echo "honeypot_user ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+# 3. Set up a working directory
+WORKDIR /opt/mhnet
+
+# 4. Copy the mhnet_setup.sh script and ensure it's executable
+COPY mhnet_setup.sh /opt/mhnet/mhnet_setup.sh
+RUN chmod +x /opt/mhnet/mhnet_setup.sh && \
+    chown honeypot_user:honeypot_user /opt/mhnet/mhnet_setup.sh
+
+# 5. Switch to the honeypot_user
+USER honeypot_user
+
+# 6. Set mhnet_setup.sh as the ENTRYPOINT
+ENTRYPOINT ["/opt/mhnet/mhnet_setup.sh"]
+
+# Optional: Define a CMD if you want to pass default arguments to the entrypoint
+# CMD ["--default-arg"]

--- a/zt-immune-system/honeypots/mhnet/mhnet_setup.sh
+++ b/zt-immune-system/honeypots/mhnet/mhnet_setup.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -e
+
+# Placeholder for custom mhnet honeypot setup and execution.
+# This script is the entrypoint for the mhnet Docker container.
+echo "mhnet_setup.sh: Placeholder for custom mhnet honeypot. Implement setup and execution logic here."
+echo "------------------------------------------------------------------------------------------"
+echo "This script should be customized to deploy and run your specific MHN/other honeypot."
+echo "The 'honeypot_user' (UID $(id -u)) is running this script."
+echo "Current working directory: $(pwd)"
+echo "------------------------------------------------------------------------------------------"
+
+# 1. Install Dependencies
+# -----------------------
+# Add commands here to install any necessary packages or dependencies
+# that are not already included in the base Docker image.
+# Remember that this script runs as 'honeypot_user'. If you need root privileges,
+# ensure 'sudo' is available and configured (it is in the generic Dockerfile).
+# Example:
+# sudo apt-get update && sudo apt-get install -y your-package
+echo "[INFO] Skipping dependency installation (placeholder)."
+
+
+# 2. Configure Honeypot
+# ---------------------
+# Add commands here to configure your honeypot.
+# This might involve creating configuration files, setting up users,
+# or initializing databases.
+# Example:
+# if [ ! -f /opt/mhnet/my_honeypot.conf ]; then
+#   echo "Creating default config..."
+#   cp /opt/mhnet/my_honeypot.conf.example /opt/mhnet/my_honeypot.conf
+#   # Further customization of the config file
+# fi
+echo "[INFO] Skipping honeypot configuration (placeholder)."
+
+
+# 3. Start Honeypot Service
+# -------------------------
+# Add commands here to start your honeypot service.
+# IMPORTANT: The service must run in the foreground. If your honeypot
+# normally daemonizes, you'll need to find a way to keep it in the foreground
+# or use a supervisor process.
+# Example:
+# exec /usr/local/bin/my_honeypot --config /opt/mhnet/my_honeypot.conf --no-daemon
+echo "[INFO] Preparing to keep container alive with 'sleep infinity' (placeholder for actual service)."
+
+
+# Keep the container alive for inspection or if the honeypot itself doesn't block.
+# Replace this with the actual command to run your honeypot in the foreground.
+sleep infinity
+
+# Example of what a real exec might look like:
+# exec myhoneypotservice --foreground --config /opt/mhnet/config.ini
+
+echo "mhnet_setup.sh: Script finished (should not happen if service is running in foreground or sleep infinity is active)."

--- a/zt-immune-system/honeypots/tpot/Dockerfile
+++ b/zt-immune-system/honeypots/tpot/Dockerfile
@@ -1,0 +1,50 @@
+# Dockerfile for T-Pot environment
+# This Dockerfile prepares a basic environment. The actual T-Pot deployment,
+# setup, and execution logic should be implemented in the start.sh script,
+# potentially using configurations from config.yaml.
+
+# 1. Start from a basic OS image
+FROM debian:bullseye-slim
+
+# 2. Install necessary dependencies
+# These are common dependencies; T-Pot or its components might need more.
+# Adjust as necessary.
+RUN apt-get update && apt-get install -y \
+    git \
+    curl \
+    sudo \
+    --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/*
+
+# 3. Create a non-root user tpot_user
+RUN groupadd -r tpot_user && \
+    useradd -r -g tpot_user -d /home/tpot_user -s /bin/bash -c "T-Pot User" tpot_user && \
+    mkdir -p /home/tpot_user && \
+    chown -R tpot_user:tpot_user /home/tpot_user
+
+# Optionally, grant sudo access if start.sh needs it.
+# Consider the security implications.
+RUN echo "tpot_user ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+# 4. Set up a working directory
+WORKDIR /opt/tpot
+
+# 5. Copy config.yaml and start.sh
+COPY config.yaml /opt/tpot/config.yaml
+COPY start.sh /opt/tpot/start.sh
+
+# Ensure config.yaml is owned by tpot_user
+RUN chown tpot_user:tpot_user /opt/tpot/config.yaml
+
+# 6. Ensure start.sh is executable and owned by tpot_user
+RUN chmod +x /opt/tpot/start.sh && \
+    chown tpot_user:tpot_user /opt/tpot/start.sh
+
+# 7. Switch to tpot_user
+USER tpot_user
+
+# 8. Set /opt/tpot/start.sh as the ENTRYPOINT
+ENTRYPOINT ["/opt/tpot/start.sh"]
+
+# Optional: Define a CMD if you want to pass default arguments to the entrypoint
+# CMD ["--default-tpot-arg"]

--- a/zt-immune-system/honeypots/tpot/config.yaml
+++ b/zt-immune-system/honeypots/tpot/config.yaml
@@ -1,0 +1,44 @@
+# T-Pot Configuration Placeholder
+# This file should be populated with actual T-Pot configuration directives
+# or configurations for the honeypots managed by T-Pot.
+
+version: "1.0"
+
+# Example: Define which honeypots T-Pot should manage or enable
+honeypots_enabled:
+  # - cowrie # SSH/Telnet honeypot
+  # - dionaea # Malware capturing honeypot
+  # - elasticpot # Elasticsearch honeypot
+  # - honeytrap # Generic TCP/UDP honeypot
+  # - adbhoney # Android Debug Bridge honeypot
+  # - citrixhoneypot # Citrix ADC honeypot
+  # - dicompot # DICOM honeypot
+  # - hellopot # Basic honeypot
+  # - heralding # Credentials checking honeypot
+  # - ipphoney # IPP honeypot
+  # - mailoney # SMTP honeypot
+  # - medpot # Medical device honeypot
+  # - rdpy # RDP honeypot
+  # - snare # Web application honeypot (Tanner)
+  # - tanner # Web application honeypot
+  placeholder_honeypot: true
+
+# Example: Configuration for backend services like ELK stack
+elk_stack:
+  enabled: false # Set to true if T-Pot should manage its own ELK stack
+  # external_elk_host: "elasticsearch.example.com"
+  # external_elk_port: 9200
+
+# Example: Network configurations
+network:
+  # T-Pot often takes over network interfaces or uses specific binding.
+  # This section would define such parameters.
+  # interface: "eth0"
+  # bind_ip: "0.0.0.0"
+  pass_through: true # Example for a mode where T-Pot might not directly bind to standard ports
+
+# Example: User-defined configurations
+user_config:
+  # admin_user: "tpotadmin"
+  # admin_password_hash: "..." # Store hashes, not plain text
+  some_api_key: "YOUR_API_KEY_HERE"

--- a/zt-immune-system/honeypots/tpot/start.sh
+++ b/zt-immune-system/honeypots/tpot/start.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+# T-Pot Startup Script Placeholder
+# This script is intended to:
+# 1. Source configurations from config.yaml (if applicable).
+# 2. Install T-Pot components or other necessary honeypot software.
+# 3. Configure the honeypots and related services.
+# 4. Launch T-Pot or its constituent parts.
+#
+# For now, it just prints a message and keeps the container running.
+
+echo "T-Pot startup script placeholder. Implement T-Pot deployment or execution logic here."
+echo "Using configuration from /opt/tpot/config.yaml (if implemented)."
+
+# Keep the container running for demonstration/debugging purposes
+sleep infinity


### PR DESCRIPTION
This commit introduces a Docker Compose based honeypot setup in the `zt-immune-system/honeypots/` directory.

Key features:
- Dockerfiles for Cowrie (SSH/Telnet), mhnet (custom placeholder), and T-Pot (environment placeholder).
- Configurations and startup scripts for each honeypot:
  - Cowrie: Configured for JSON logging to stdout, specific hostname.
  - mhnet: Basic setup script placeholder for your customization.
  - T-Pot: Placeholders for config and startup, allowing for custom T-Pot component deployment.
- `docker-compose.yml`: Orchestrates the honeypot services, including:
  - Network isolation (`honeynet`).
  - Persistent data volumes (`cowrie_data`, `mhnet_data`).
  - Security options (`no-new-privileges`, common seccomp profile).
  - Environment variables for basic customization.
- `README.md`: Comprehensive documentation covering setup, configuration, security, and extensibility.

This setup provides a baseline for deploying multiple honeypots, enhancing the threat intelligence capabilities of the ZT Immune System. The mhnet and T-Pot services are designed as flexible templates for further development and customization.